### PR TITLE
Remove fetchMany

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "printWidth": 120,
+  "singleQuote": true
+}

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ $ npm i @abcnews/terminus-fetch
 ## Usage
 
 ```js
-import { fetchOne, fetchMany, search } from '@abcnews/terminus-fetch';
+import { fetchOne, search } from '@abcnews/terminus-fetch';
 // We export fetchOne by default, as it's most commmonly used:
 import fetchOne from '@abcnews/terminus-fetch';
 
@@ -38,19 +38,6 @@ fetchOne({ id: 123860, type: 'show', source: 'iview' })
   .then(doc => {
     console.log(doc);
     // > { id: 123860, docType: "show", contentSource: "iview", ... }
-  })
-  .catch(err => console.error(err));
-
-// You can even fetch multiple documents at once:
-
-fetchMany([10736062, { id: 10734902, type: 'video' }, { id: 123860, type: 'show', source: 'iview' }])
-  .then(docs => {
-    console.log(docs);
-    // > [
-    //     { id: 10736062, docType: "Article", contentSource: "coremedia", ... },
-    //     { id: 10734902, docType: "Video", contentSource: "coremedia", ... },
-    //     { id: 123860, docType: "show", contentSource: "iview", ... }
-    //   ]
   })
   .catch(err => console.error(err));
 
@@ -123,34 +110,6 @@ If the `done` callback is omitted then the return value will be a Promise.
   apikey: '54564fe299e84f46a57057266fcf233b' /* (News) */
 }
 ```
-
-### `fetchMany`
-
-```ts
-declare function fetchMany(
-  documentsOptions: [
-
-      | string
-      | number
-      | {
-          source?: string;
-          type?: string;
-          id?: string | number;
-        }
-  ],
-  apiOptions: {
-    apikey?: string;
-    forceLive?: boolean;
-    forcePreview?: boolean;
-    isTeasable?: string;
-  },
-  done?: (err?: ProgressEvent | Error, doc?: Object) => void
-): void | Promise<Object>;
-```
-
-This works in a similar way to `fetchOne`, but the first argument is an array of options for each document you want returned, and shared options for the API are separated out into a 2nd argument, bumping the optional callback into 3rd position.
-
-If the `done` callback is omitted then the return value will be a Promise.
 
 ### `search`
 

--- a/example/src/index.ts
+++ b/example/src/index.ts
@@ -1,4 +1,4 @@
-import terminusFetch, { fetchOne, search } from '../../src/index';
+import terminusFetch, { fetchOne, fetchMany, search } from '../../src/index';
 
 const FETCH_OPTIONS = [
   10736062,
@@ -65,3 +65,8 @@ SEARCH_OPTIONS.forEach(options =>
     .then(docs => console.log(`[search][env resolved] options=${JSON.stringify(options)}`, docs))
     .catch(err => console.log('[search][env rejected]', err))
 );
+
+// Deprecated `fetchMany` function. Should reject
+
+fetchMany(null, null, err => console.log('[fetchMany][env rejected]', err));
+fetchMany(null, null).catch(err => console.log('[fetchMany][env rejected]', err));

--- a/example/src/index.ts
+++ b/example/src/index.ts
@@ -1,4 +1,4 @@
-import terminusFetch, { fetchOne, fetchMany, search } from '../../src';
+import terminusFetch, { fetchOne, search } from '../../src/index';
 
 const FETCH_OPTIONS = [
   10736062,
@@ -29,17 +29,23 @@ function ensureObject(options) {
 FETCH_OPTIONS.forEach(options =>
   terminusFetch(options, (err, doc) => console.log(`[env] options=${JSON.stringify(options)}`, err, doc))
 );
-FETCH_OPTIONS.map(x => ({ ...ensureObject(x), ...FETCH_OPTIONS_TEASABLE_MIXIN })).forEach(options =>
+FETCH_OPTIONS.map(x => ({
+  ...ensureObject(x),
+  ...FETCH_OPTIONS_TEASABLE_MIXIN
+})).forEach(options =>
   terminusFetch(options, (err, doc) => console.log(`[env:teasable] options=${JSON.stringify(options)}`, err, doc))
 );
-FETCH_OPTIONS.map(x => ({ ...ensureObject(x), forceLive: true })).forEach(options =>
+FETCH_OPTIONS.map(x => ({
+  ...ensureObject(x),
+  forceLive: true
+})).forEach(options =>
   terminusFetch(options, (err, doc) => console.log(`[live] options=${JSON.stringify(options)}`, err, doc))
 );
-FETCH_OPTIONS.map(x => ({ ...ensureObject(x), forcePreview: true })).forEach(options =>
+FETCH_OPTIONS.map(x => ({
+  ...ensureObject(x),
+  forcePreview: true
+})).forEach(options =>
   terminusFetch(options, (err, doc) => console.log(`[preview] options=${JSON.stringify(options)}`, err, doc))
-);
-fetchMany(FETCH_OPTIONS, null, (err, doc) =>
-  console.log(`[many][env] options=${JSON.stringify(FETCH_OPTIONS)};null`, err, doc)
 );
 
 // Using promises
@@ -48,16 +54,6 @@ FETCH_OPTIONS.forEach(options => {
     .then(doc => console.log(`[env resolved] options=${JSON.stringify(options)}`, doc))
     .catch(err => console.log('[env rejected]', err));
 });
-fetchMany(FETCH_OPTIONS, FETCH_OPTIONS_TEASABLE_MIXIN)
-  .then(docs =>
-    console.log(
-      `[many][env:teasable resolved] options=${JSON.stringify(FETCH_OPTIONS)};${JSON.stringify(
-        FETCH_OPTIONS_TEASABLE_MIXIN
-      )}`,
-      docs
-    )
-  )
-  .catch(err => console.log('[many][env:teasable rejected]', err));
 
 terminusFetch(1241241241241245125125125125)
   .then(doc => console.log(`[error? resolved]`, doc))

--- a/src/index.ts
+++ b/src/index.ts
@@ -81,39 +81,11 @@ function fetchMany(
   done: Done<TerminusDocument[]>
 ): void;
 function fetchMany(
-  documentsOptions: DocumentOptionsOrDocumentID[],
-  apiOptions?: APIOptions,
+  _documentsOptions: DocumentOptionsOrDocumentID[],
+  _apiOptions?: APIOptions,
   done?: Done<TerminusDocument[]>
 ): any {
-  return asyncTask(
-    new Promise((resolve, reject) => {
-      const _documentsOptions = (documentsOptions || []).map(documentOptions => ({
-        ...DEFAULT_DOCUMENT_OPTIONS,
-        ...ensureIsDocumentOptions(documentOptions)
-      }));
-      const invalidID = _documentsOptions.map(({ id }) => id).find(isDocumentIDInvalid);
-
-      if (invalidID) {
-        return reject(new Error(`Invalid ID: ${invalidID}`));
-      }
-
-      const { apikey, forceLive, forcePreview, isTeasable } = {
-        ...DEFAULT_API_OPTIONS,
-        ...(apiOptions || <APIOptions>{})
-      };
-
-      request(
-        `${getEndpoint(forceLive, forcePreview)}/api/v1/${
-          isTeasable ? 'teasable' : ''
-        }content?ids=${_documentsOptions
-          .map(({ source, type, id }) => `${source}://${type}/${id}`)
-          .join(',')}&apikey=${apikey}`,
-        response => resolve(response._embedded && flattenEmbeddedProps(response._embedded)),
-        reject
-      );
-    }),
-    done
-  );
+  return asyncTask(Promise.reject(new Error('The `fetchMany` function is no longer supported')), done);
 }
 
 function search(searchOptions: SearchOptions): Promise<TerminusDocument[]>;


### PR DESCRIPTION
Terminus has deprecated their batch API, and will remove support by the end of the year.

This PR removes the `fetchMany` function which depended on it, throwing a useful error message if you still try to use it after you update.

This should cause a major bump, if accepted.