### PR TITLE
[BREAKING] Change how image renditions are parsed

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,17 +25,17 @@
       "dev": true
     },
     "@babel/core": {
-      "version": "7.13.1",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.13.1.tgz",
-      "integrity": "sha512-FzeKfFBG2rmFtGiiMdXZPFt/5R5DXubVi82uYhjGX4Msf+pgYQMCFIqFXZWs5vbIYbf14VeBIgdGI03CDOOM1w==",
+      "version": "7.13.8",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.13.8.tgz",
+      "integrity": "sha512-oYapIySGw1zGhEFRd6lzWNLWFX2s5dA/jm+Pw/+59ZdXtjyIuwlXbrId22Md0rgZVop+aVoqow2riXhBLNyuQg==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.12.13",
         "@babel/generator": "^7.13.0",
-        "@babel/helper-compilation-targets": "^7.13.0",
+        "@babel/helper-compilation-targets": "^7.13.8",
         "@babel/helper-module-transforms": "^7.13.0",
         "@babel/helpers": "^7.13.0",
-        "@babel/parser": "^7.13.0",
+        "@babel/parser": "^7.13.4",
         "@babel/template": "^7.12.13",
         "@babel/traverse": "^7.13.0",
         "@babel/types": "^7.13.0",
@@ -44,7 +44,7 @@
         "gensync": "^1.0.0-beta.2",
         "json5": "^2.1.2",
         "lodash": "^4.17.19",
-        "semver": "7.0.0",
+        "semver": "^6.3.0",
         "source-map": "^0.5.0"
       },
       "dependencies": {
@@ -58,15 +58,15 @@
           }
         },
         "@babel/compat-data": {
-          "version": "7.13.6",
-          "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.13.6.tgz",
-          "integrity": "sha512-VhgqKOWYVm7lQXlvbJnWOzwfAQATd2nV52koT0HZ/LdDH0m4DUDwkKYsH+IwpXb+bKPyBJzawA4I6nBKqZcpQw==",
+          "version": "7.13.8",
+          "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.13.8.tgz",
+          "integrity": "sha512-EaI33z19T4qN3xLXsGf48M2cDqa6ei9tPZlfLdb2HC+e/cFtREiRd8hdSqDbwdLB0/+gLwqJmCYASH0z2bUdog==",
           "dev": true
         },
         "@babel/generator": {
-          "version": "7.13.0",
-          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.13.0.tgz",
-          "integrity": "sha512-zBZfgvBB/ywjx0Rgc2+BwoH/3H+lDtlgD4hBOpEv5LxRnYsm/753iRuLepqnYlynpjC3AdQxtxsoeHJoEEwOAw==",
+          "version": "7.13.9",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.13.9.tgz",
+          "integrity": "sha512-mHOOmY0Axl/JCTkxTU6Lf5sWOg/v8nUa+Xkt4zMTftX0wqmb6Sh7J8gvcehBw7q0AhrhAR+FDacKjCZ2X8K+Sw==",
           "dev": true,
           "requires": {
             "@babel/types": "^7.13.0",
@@ -75,15 +75,15 @@
           }
         },
         "@babel/helper-compilation-targets": {
-          "version": "7.13.0",
-          "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.13.0.tgz",
-          "integrity": "sha512-SOWD0JK9+MMIhTQiUVd4ng8f3NXhPVQvTv7D3UN4wbp/6cAHnB2EmMaU1zZA2Hh1gwme+THBrVSqTFxHczTh0Q==",
+          "version": "7.13.8",
+          "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.13.8.tgz",
+          "integrity": "sha512-pBljUGC1y3xKLn1nrx2eAhurLMA8OqBtBP/JwG4U8skN7kf8/aqwwxpV1N6T0e7r6+7uNitIa/fUxPFagSXp3A==",
           "dev": true,
           "requires": {
-            "@babel/compat-data": "^7.13.0",
+            "@babel/compat-data": "^7.13.8",
             "@babel/helper-validator-option": "^7.12.17",
             "browserslist": "^4.14.5",
-            "semver": "7.0.0"
+            "semver": "^6.3.0"
           }
         },
         "@babel/helper-function-name": {
@@ -178,9 +178,9 @@
           "dev": true
         },
         "@babel/highlight": {
-          "version": "7.12.13",
-          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.12.13.tgz",
-          "integrity": "sha512-kocDQvIbgMKlWxXe9fof3TQ+gkIPOUSEYhJjqUjvKMez3krV7vbzYCDq39Oj11UAVK7JqPVGQPlgE85dPNlQww==",
+          "version": "7.13.8",
+          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.13.8.tgz",
+          "integrity": "sha512-4vrIhfJyfNf+lCtXC2ck1rKSzDwciqF7IWFhXXrSOUC2O5DrVp+w4c6ed4AllTxhTkUP5x2tYj41VaxdVMMRDw==",
           "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.12.11",
@@ -189,9 +189,9 @@
           }
         },
         "@babel/parser": {
-          "version": "7.13.4",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.4.tgz",
-          "integrity": "sha512-uvoOulWHhI+0+1f9L4BoozY7U5cIkZ9PgJqvb041d6vypgUmtVPG4vmGm4pSggjl8BELzvHyUeJSUyEMY6b+qA==",
+          "version": "7.13.9",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.9.tgz",
+          "integrity": "sha512-nEUfRiARCcaVo3ny3ZQjURjHQZUo/JkEw7rLlSZy/psWGnvwXFtPcr6jb7Yb41DVW5LTe6KRq9LGleRNsg1Frw==",
           "dev": true
         },
         "@babel/template": {
@@ -234,9 +234,9 @@
           }
         },
         "semver": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.0.0.tgz",
-          "integrity": "sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==",
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
           "dev": true
         }
       }
@@ -1075,9 +1075,9 @@
           }
         },
         "@babel/generator": {
-          "version": "7.13.0",
-          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.13.0.tgz",
-          "integrity": "sha512-zBZfgvBB/ywjx0Rgc2+BwoH/3H+lDtlgD4hBOpEv5LxRnYsm/753iRuLepqnYlynpjC3AdQxtxsoeHJoEEwOAw==",
+          "version": "7.13.9",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.13.9.tgz",
+          "integrity": "sha512-mHOOmY0Axl/JCTkxTU6Lf5sWOg/v8nUa+Xkt4zMTftX0wqmb6Sh7J8gvcehBw7q0AhrhAR+FDacKjCZ2X8K+Sw==",
           "dev": true,
           "requires": {
             "@babel/types": "^7.13.0",
@@ -1115,9 +1115,9 @@
           }
         },
         "@babel/highlight": {
-          "version": "7.12.13",
-          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.12.13.tgz",
-          "integrity": "sha512-kocDQvIbgMKlWxXe9fof3TQ+gkIPOUSEYhJjqUjvKMez3krV7vbzYCDq39Oj11UAVK7JqPVGQPlgE85dPNlQww==",
+          "version": "7.13.8",
+          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.13.8.tgz",
+          "integrity": "sha512-4vrIhfJyfNf+lCtXC2ck1rKSzDwciqF7IWFhXXrSOUC2O5DrVp+w4c6ed4AllTxhTkUP5x2tYj41VaxdVMMRDw==",
           "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.12.11",
@@ -1126,9 +1126,9 @@
           }
         },
         "@babel/parser": {
-          "version": "7.13.4",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.4.tgz",
-          "integrity": "sha512-uvoOulWHhI+0+1f9L4BoozY7U5cIkZ9PgJqvb041d6vypgUmtVPG4vmGm4pSggjl8BELzvHyUeJSUyEMY6b+qA==",
+          "version": "7.13.9",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.9.tgz",
+          "integrity": "sha512-nEUfRiARCcaVo3ny3ZQjURjHQZUo/JkEw7rLlSZy/psWGnvwXFtPcr6jb7Yb41DVW5LTe6KRq9LGleRNsg1Frw==",
           "dev": true
         },
         "@babel/template": {
@@ -9187,9 +9187,9 @@
       "dev": true
     },
     "husky": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/husky/-/husky-5.1.1.tgz",
-      "integrity": "sha512-80LZ736V0Nr4/st0c2COYaMbEQhHNmAbLMN8J/kLk7/mo0QdUkUGNDjv/7jVkhug377Wh8wfbWyaVXEJ/h2B/Q==",
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-5.1.3.tgz",
+      "integrity": "sha512-fbNJ+Gz5wx2LIBtMweJNY1D7Uc8p1XERi5KNRMccwfQA+rXlxWNSdUxswo0gT8XqxywTIw7Ywm/F4v/O35RdMg==",
       "dev": true
     },
     "iconv-lite": {
@@ -15662,9 +15662,9 @@
       }
     },
     "rollup": {
-      "version": "2.39.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.39.1.tgz",
-      "integrity": "sha512-9rfr0Z6j+vE+eayfNVFr1KZ+k+jiUl2+0e4quZafy1x6SFCjzFspfRSO2ZZQeWeX9noeDTUDgg6eCENiEPFvQg==",
+      "version": "2.40.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.40.0.tgz",
+      "integrity": "sha512-WiOGAPbXoHu+TOz6hyYUxIksOwsY/21TRWoO593jgYt8mvYafYqQl+axaA8y1z2HFazNUUrsMSjahV2A6/2R9A==",
       "dev": true,
       "requires": {
         "fsevents": "~2.3.1"

--- a/package.json
+++ b/package.json
@@ -40,11 +40,11 @@
     "release": "np"
   },
   "devDependencies": {
-    "@babel/core": "^7.13.1",
-    "husky": "^5.1.1",
+    "@babel/core": "^7.13.8",
+    "husky": "^5.1.3",
     "np": "^7.4.0",
     "parcel-bundler": "^1.12.4",
-    "rollup": "^2.39.1",
+    "rollup": "^2.40.0",
     "tsdx": "^0.14.1",
     "tslib": "^2.1.0",
     "typescript": "^4.2.2"

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,72 +1,31 @@
-import { TIERS } from '@abcnews/env-utils';
-import { getImageRendition, getImageRenditions } from './index';
+import { getImages } from './index';
 
-enum RESULTS {
-  BIG_16X9_LIVE = 'https://live-production.wcms.abc-cdn.net.au/key?impolicy=wcms_crop_resize&cropH=360&cropW=640&xPos=0&yPos=0&width=862&height=485',
-  BIG_16X9_PREVIEW = 'https://preview-production.wcms.abc-cdn.net.au/key?impolicy=wcms_crop_resize&cropH=360&cropW=640&xPos=0&yPos=0&width=862&height=485',
-  SMALL_16X9_LIVE = 'https://live-production.wcms.abc-cdn.net.au/key?impolicy=wcms_crop_resize&cropH=360&cropW=640&xPos=0&yPos=0&width=100&height=56',
-  BIG_1X1_LIVE = 'https://live-production.wcms.abc-cdn.net.au/key?impolicy=wcms_crop_resize&cropH=405&cropW=405&xPos=117&yPos=0&width=862&height=862',
-  SMALL_1X1_LIVE = 'https://live-production.wcms.abc-cdn.net.au/key?impolicy=wcms_crop_resize&cropH=405&cropW=405&xPos=117&yPos=0&width=100&height=100',
-  TINY_1X1_LIVE = 'https://live-production.wcms.abc-cdn.net.au/key?impolicy=wcms_crop_resize&cropH=405&cropW=405&xPos=117&yPos=0&width=5&height=5'
-}
+import * as v2_standard_complete from './test-data/v2-standard-complete';
+import * as v2_standard_proxy from './test-data/v2-standard-proxy';
 
-describe('getImageRendition', () => {
-  describe('live - detected', () => {
-    test('big 16x9', () => {
-      expect(getImageRendition('key', { cropWidth: 640, cropHeight: 360, x: 0, y: 0 }, 862)).toBe(
-        RESULTS.BIG_16X9_LIVE
-      );
+import * as v1_standard_complete from './test-data/v1-standard-complete';
+import * as v1_custom_complete from './test-data/v1-custom-complete';
+import * as v1_standard_proxy_title_update from './test-data/v1-standard-proxy-title-update';
+
+describe('getImages', () => {
+  describe('Terminus v2', () => {
+    test('Standard image with all relevant fields complete', () => {
+      expect(getImages(v2_standard_complete.input)).toEqual(v2_standard_complete.result);
     });
-    test('small 16x9', () => {
-      expect(getImageRendition('key', { cropWidth: 640, cropHeight: 360, x: 0, y: 0 }, 100)).toBe(
-        RESULTS.SMALL_16X9_LIVE
-      );
-    });
-    test('big 1x1', () => {
-      expect(getImageRendition('key', { cropWidth: 405, cropHeight: 405, x: 117, y: 0 }, 862)).toBe(
-        RESULTS.BIG_1X1_LIVE
-      );
-    });
-    test('tiny 1x1', () => {
-      expect(getImageRendition('key', { cropWidth: 405, cropHeight: 405, x: 117, y: 0 }, 5)).toBe(
-        RESULTS.TINY_1X1_LIVE
-      );
+    test('Standard image proxy with all relevant fields complete', () => {
+      expect(getImages(v2_standard_proxy.input)).toEqual(v2_standard_proxy.result);
     });
   });
-
-  describe('live - forced', () => {
-    test('big 16x9', () => {
-      expect(getImageRendition('key', { cropWidth: 640, cropHeight: 360, x: 0, y: 0 }, 862, TIERS.LIVE)).toBe(
-        RESULTS.BIG_16X9_LIVE
-      );
+  describe('Terminus v1', () => {
+    test('Standard image with all the relevant fields complete', () => {
+      expect(getImages(v1_standard_complete.input)).toEqual(v1_standard_complete.result);
     });
-  });
-
-  describe('preview - forced', () => {
-    test('big 16x9', () => {
-      expect(getImageRendition('key', { cropWidth: 640, cropHeight: 360, x: 0, y: 0 }, 862, TIERS.PREVIEW)).toBe(
-        RESULTS.BIG_16X9_PREVIEW
-      );
+    test('Standard image proxy with an updated title', () => {
+      expect(getImages(v1_standard_proxy_title_update.input)).toEqual(v1_standard_proxy_title_update.result);
     });
-  });
-});
-
-describe('getImageRenditions', () => {
-  test('live - detected', () => {
-    expect(
-      getImageRenditions(
-        'key',
-        {
-          '16x9': { cropWidth: 640, cropHeight: 360, x: 0, y: 0 },
-          '1x1': { cropWidth: 405, cropHeight: 405, x: 117, y: 0 }
-        },
-        [862, 100]
-      )
-    ).toEqual([
-      { ratio: '16x9', width: 862, url: RESULTS.BIG_16X9_LIVE },
-      { ratio: '16x9', width: 100, url: RESULTS.SMALL_16X9_LIVE },
-      { ratio: '1x1', width: 862, url: RESULTS.BIG_1X1_LIVE },
-      { ratio: '1x1', width: 100, url: RESULTS.SMALL_1X1_LIVE }
-    ]);
+    test('Custom image with all the relevant fields complete', () => {
+      expect(getImages(v1_custom_complete.input)).toEqual(v1_custom_complete.result);
+      expect(getImages(v1_custom_complete.input, [100, 200])).toEqual(v1_custom_complete.result);
+    });
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import { TIERS, getTier } from '@abcnews/env-utils';
+import { getImages } from './lib/images';
 
 type DocumentID = string | number;
 type APIVersions = 'v1' | 'v2';
@@ -29,24 +30,11 @@ interface TerminusDocument {
 type Callback<E, T> = (err?: E, result?: T) => void;
 type Done<T> = Callback<ProgressEvent | Error, T>;
 
-type CropData = {
-  cropHeight: number;
-  cropWidth: number;
-  x: number;
-  y: number;
-};
-
-type CropsData = {
-  [key: string]: CropData;
-};
-
 // This built JS asset _will_be_ rewritten on-the-fly, so we need to obscure the origin somewhat
 const GENIUNE_MEDIA_ENDPOINT_PATTERN = new RegExp(['http', '://', 'mpegmedia', '.abc.net.au'].join(''), 'g');
 const PROXIED_MEDIA_ENDPOINT = 'https://abcmedia.akamaized.net';
 const TERMINUS_LIVE_ENDPOINT = 'https://api.abc.net.au/terminus';
 const TERMINUS_PREVIEW_ENDPOINT = 'https://api-preview.terminus.abc-prod.net.au';
-const IMAGE_LIVE_ENDPOINT = 'https://live-production.wcms.abc-cdn.net.au';
-const IMAGE_PREVIEW_ENDPOINT = 'https://preview-production.wcms.abc-cdn.net.au';
 const DEFAULT_API_OPTIONS: APIOptions = {
   apikey: '54564fe299e84f46a57057266fcf233b',
   version: 'v2'
@@ -159,39 +147,5 @@ function flattenEmbeddedProps(_embedded: { [key: string]: TerminusDocument[] }) 
   return Object.keys(_embedded).reduce((memo, key) => memo.concat(_embedded[key]), [] as TerminusDocument[]);
 }
 
-// Generates ABC CDN's Akamai crop/resize image binary URLs
-// This is only relevant for Terminus v2 data
-function getImageRendition(binaryKey: string, crop: CropData, targetWidth: number, force?: TIERS): string {
-  const ratio = crop.cropHeight / crop.cropWidth;
-  const endpoint =
-    (getTier() === TIERS.PREVIEW || force === TIERS.PREVIEW) && force !== TIERS.LIVE
-      ? IMAGE_PREVIEW_ENDPOINT
-      : IMAGE_LIVE_ENDPOINT;
-  return `${endpoint}/${binaryKey}?impolicy=wcms_crop_resize&cropH=${crop.cropHeight}&cropW=${crop.cropWidth}&xPos=${
-    crop.x
-  }&yPos=${crop.y}&width=${targetWidth}&height=${Math.round(targetWidth * ratio)}`;
-}
-
-type ImageRendition = { width: number; ratio: string; url: string };
-
-function getImageRenditions(
-  binaryKey: string,
-  crops: CropsData,
-  targetWidths: number[],
-  force?: TIERS
-): ImageRendition[] {
-  const result: ImageRendition[] = [];
-  Object.keys(crops).forEach(ratio => {
-    targetWidths.forEach(targetWidth => {
-      result.push({
-        url: getImageRendition(binaryKey, crops[ratio], targetWidth, force),
-        width: targetWidth,
-        ratio: ratio
-      });
-    });
-  });
-  return result;
-}
-
 export default fetchOne;
-export { fetchOne, search, getImageRendition, getImageRenditions };
+export { fetchOne, search, getImages };

--- a/src/lib/images.ts
+++ b/src/lib/images.ts
@@ -1,0 +1,217 @@
+const DEFAULT_TARGET_WIDTHS = [160, 240, 480, 700, 940, 1400, 2150];
+
+type ImageData = {
+  cmid: string;
+  title?: string;
+  alt?: string;
+  caption?: string;
+  attribution?: string;
+  canonicalURL: string;
+  renditions: ImageRendition[];
+};
+type ImageRendition = { width: number; height: number; ratio: string; url: string; isUndersizedBinary: boolean };
+
+type TerminusImageDocument = {
+  id: string;
+  title?: string;
+  alt?: string;
+  caption?: string;
+  byLine?: {
+    plain: string;
+  };
+  canonicalURL: string;
+  media: {
+    image: {
+      primary: {
+        binaryKey: string;
+        ratios: TerminusImageDocumentRatios;
+        complete: { url: string }[];
+      };
+    };
+  };
+};
+type TerminusImageDocumentRatios = {
+  [key: string]: TerminusCropData;
+};
+
+type TerminusCropData = {
+  cropHeight: number;
+  cropWidth: number;
+  x: number;
+  y: number;
+};
+
+const extractEndpoint = (url: string) => {
+  const match = url.match(/https:\/\/[^\/]+/);
+  if (!match) throw new Error('Could not determine image CDN endpoint');
+  return match[0];
+};
+
+const isTerminusImageDocumentRatios = (obj: any): obj is TerminusImageDocumentRatios => {
+  if (typeof obj !== 'object') return false;
+  for (const key in obj) {
+    if (typeof key !== 'string') return false;
+    if (typeof obj[key].cropWidth !== 'number') return false;
+    if (typeof obj[key].cropHeight !== 'number') return false;
+    if (typeof obj[key].x !== 'number') return false;
+    if (typeof obj[key].y !== 'number') return false;
+  }
+  return true;
+};
+
+const isTerminusImageDocument = (obj: any): obj is TerminusImageDocument => {
+  if (typeof obj !== 'object') return false;
+  if (obj?.docType !== 'Image' && obj?.docType !== 'ImageProxy') return false;
+  if (typeof obj?.id !== 'string') return false;
+  if (typeof obj?.media?.image?.primary?.binaryKey !== 'string') return false;
+  if (typeof obj?.media?.image?.primary?.complete[0]?.url !== 'string') return false;
+  if (!isTerminusImageDocumentRatios(obj?.media?.image?.primary?.ratios)) return false;
+  return true;
+};
+
+// Generates ABC CDN's Akamai crop/resize image binary URLs
+// This is only relevant for Terminus v2 data
+function generateImageRenditionURL(
+  binaryKey: string,
+  crop: TerminusCropData,
+  targetWidth: number,
+  endpoint: string
+): string {
+  const ratio = crop.cropHeight / crop.cropWidth;
+  return `${endpoint}/${binaryKey}?impolicy=wcms_crop_resize&cropH=${crop.cropHeight}&cropW=${crop.cropWidth}&xPos=${
+    crop.x
+  }&yPos=${crop.y}&width=${targetWidth}&height=${Math.round(targetWidth * ratio)}`;
+}
+
+function generateImageRenditions(
+  binaryKey: string,
+  crops: TerminusImageDocumentRatios,
+  targetWidths: number[] = DEFAULT_TARGET_WIDTHS,
+  endpoint: string
+): ImageRendition[] {
+  const result: ImageRendition[] = [];
+  Object.keys(crops).forEach(ratio => {
+    targetWidths.forEach(targetWidth => {
+      result.push({
+        url: generateImageRenditionURL(binaryKey, crops[ratio], targetWidth, endpoint),
+        width: targetWidth,
+        height: Math.round(targetWidth * (crops[ratio].cropHeight / crops[ratio].cropWidth)),
+        ratio: ratio,
+        isUndersizedBinary: crops[ratio].cropWidth < targetWidth
+      });
+    });
+  });
+  return result;
+}
+
+function getImages(doc: any, targetWidths: number[] = DEFAULT_TARGET_WIDTHS): ImageData {
+  if (isTerminusImageDocument(doc)) {
+    const { title, alt, id, caption, canonicalURL } = doc;
+    return {
+      cmid: id,
+      title,
+      alt,
+      caption,
+      attribution: doc.byLine?.plain,
+      canonicalURL,
+      renditions: generateImageRenditions(
+        doc.media.image.primary.binaryKey,
+        doc.media.image.primary.ratios,
+        targetWidths,
+        extractEndpoint(doc.media.image.primary.complete[0].url)
+      )
+    };
+  }
+
+  if (isLegacyTerminusImageDocument(doc)) {
+    const images = doc.media.image.primary.complete;
+    const { title, alt, id: cmid, caption, attribution, canonicalURL } = doc;
+    return {
+      alt,
+      cmid,
+      title,
+      caption,
+      attribution,
+      canonicalURL,
+      renditions: images.map(({ ratio, width, height, url }) => {
+        return {
+          ratio: ratio || getRatioString(width, height),
+          width,
+          height,
+          url,
+          isUndersizedBinary: false
+        };
+      })
+    };
+  }
+
+  throw new Error('The document passed was not a valid terminus image document');
+}
+
+/*
+ * ========================================================
+ * Stuff below here is transitional and can be removed once
+ * the transition to CM10 and Terminus v2 is complete.
+ * ========================================================
+ */
+type LegacyTerminusImageDocument = {
+  id: string;
+  title?: string;
+  alt?: string;
+  caption?: string;
+  attribution?: string;
+  canonicalURL: string;
+  media: {
+    image: {
+      primary: {
+        complete: LegacyTerminusImageDocumentImages;
+      };
+    };
+  };
+};
+
+type LegacyTerminusImageDocumentImages = LegacyTerminusImageDocumentImage[];
+type LegacyTerminusImageDocumentImage = {
+  width: number;
+  height: number;
+  url: string;
+  ratio?: string;
+};
+
+const greatestCommonFactor = (a: number, b: number) => {
+  while (a) {
+    const t = a;
+    a = b % a;
+    b = t;
+  }
+  return b;
+};
+
+const getRatioString = (width: number, height: number) => {
+  const gcf = greatestCommonFactor(width, height);
+  return `${width / gcf}x${height / gcf}`;
+};
+
+const isLegacyTerminusImageDocument = (obj: any): obj is LegacyTerminusImageDocument => {
+  if (typeof obj !== 'object') return false;
+  if (obj?.docType !== 'Image' && obj?.docType !== 'ImageProxy' && obj?.docType !== 'CustomImage') return false;
+  if (typeof obj?.id !== 'string') return false;
+  if (!isLegacyTerminusImageDocumentImages(obj?.media?.image?.primary?.complete)) return false;
+  return true;
+};
+
+const isLegacyTerminusImageDocumentImage = (obj: any): obj is LegacyTerminusImageDocumentImage => {
+  if (typeof obj !== 'object') return false;
+  if (typeof obj.width !== 'number') return false;
+  if (typeof obj.height !== 'number') return false;
+  if (typeof obj.url !== 'string') return false;
+  return true;
+};
+
+const isLegacyTerminusImageDocumentImages = (obj: any): obj is LegacyTerminusImageDocumentImages => {
+  if (!Array.isArray(obj)) return false;
+  if (!obj.every(isLegacyTerminusImageDocumentImage)) return false;
+  return true;
+};
+
+export { getImages };

--- a/src/test-data/v1-custom-complete.ts
+++ b/src/test-data/v1-custom-complete.ts
@@ -1,0 +1,55 @@
+export const input = {
+  _links: { self: { href: '/api/v1/content/coremedia/customimage/7125936' } },
+  alt: 'Placeholder custom image alt text',
+  attribution: 'Supplied: image generator',
+  byLine: { type: 'element', tagname: 'p', children: [{ type: 'text', content: 'Supplied: image generator' }] },
+  canonicalURL: 'http://nucwed.aus.aunty.abc.net.au/news/2016-06-07/placeholder-custom-image/7125936',
+  caption: 'Placeholder custom image caption',
+  contentSource: 'coremedia',
+  dates: {
+    displayPublished: '2016-06-07T05:31:26+00:00',
+    displayUpdated: '2016-06-07T05:34:04+00:00',
+    published: '2016-06-07T05:31:26+00:00',
+    updated: '2016-06-07T05:34:04+00:00'
+  },
+  docType: 'CustomImage',
+  id: '7125936',
+  lang: 'en',
+  media: {
+    image: {
+      primary: {
+        complete: [
+          {
+            height: 440,
+            size: 12856,
+            url: 'http://nucwed.aus.aunty.abc.net.au/cm/lb/7125936/data/placeholder-custom-image-data.png',
+            width: 440
+          }
+        ],
+        images: {
+          '440x440': 'http://nucwed.aus.aunty.abc.net.au/cm/lb/7125936/data/placeholder-custom-image-data.png'
+        }
+      }
+    }
+  },
+  title: 'Placeholder Custom Image',
+  titleAlt: { lg: 'Placeholder Custom Image', md: 'Placeholder Custom Image', sm: 'Placeholder Custom Image' }
+};
+
+export const result = {
+  cmid: '7125936',
+  title: 'Placeholder Custom Image',
+  alt: 'Placeholder custom image alt text',
+  caption: 'Placeholder custom image caption',
+  attribution: 'Supplied: image generator',
+  canonicalURL: 'http://nucwed.aus.aunty.abc.net.au/news/2016-06-07/placeholder-custom-image/7125936',
+  renditions: [
+    {
+      height: 440,
+      ratio: '1x1',
+      isUndersizedBinary: false,
+      url: 'http://nucwed.aus.aunty.abc.net.au/cm/lb/7125936/data/placeholder-custom-image-data.png',
+      width: 440
+    }
+  ]
+};

--- a/src/test-data/v1-standard-complete.ts
+++ b/src/test-data/v1-standard-complete.ts
@@ -1,0 +1,250 @@
+export const input = {
+  _links: { self: { href: '/api/v1/content/coremedia/image/7125904' } },
+  alt: 'Placeholder Image alt text',
+  attribution: 'Supplied: image generator',
+  byLine: { type: 'element', tagname: 'p', children: [{ type: 'text', content: 'Supplied: image generator' }] },
+  canonicalURL: 'http://nucwed.aus.aunty.abc.net.au/news/2017-01-10/placeholder-image/7125904',
+  caption: 'Placeholder image caption text',
+  contentSource: 'coremedia',
+  dates: {
+    displayPublished: '2017-01-09T23:23:26+00:00',
+    published: '2017-01-09T23:23:26+00:00',
+    updated: '2017-01-09T23:23:26+00:00'
+  },
+  docType: 'Image',
+  id: '7125904',
+  lang: 'en',
+  media: {
+    image: {
+      primary: {
+        complete: [
+          {
+            height: 90,
+            ratio: '16x9',
+            size: 1617,
+            url: 'http://nucwed.aus.aunty.abc.net.au/cm/rimage/7125904-16x9-thumbnail.png?v=3',
+            width: 160
+          },
+          {
+            height: 394,
+            ratio: '16x9',
+            size: 9253,
+            url: 'http://nucwed.aus.aunty.abc.net.au/cm/rimage/7125904-16x9-large.png?v=3',
+            width: 700
+          },
+          {
+            height: 160,
+            ratio: '1x1',
+            size: 2443,
+            url: 'http://nucwed.aus.aunty.abc.net.au/cm/rimage/7125904-1x1-thumbnail.png?v=3',
+            width: 160
+          },
+          {
+            height: 627,
+            ratio: '1x1',
+            size: 7340,
+            url: 'http://nucwed.aus.aunty.abc.net.au/cm/rimage/7125904-1x1-large.png?v=3',
+            width: 627
+          },
+          {
+            height: 107,
+            ratio: '3x2',
+            size: 1657,
+            url: 'http://nucwed.aus.aunty.abc.net.au/cm/rimage/7125904-3x2-thumbnail.png?v=3',
+            width: 160
+          },
+          {
+            height: 467,
+            ratio: '3x2',
+            size: 9589,
+            url: 'http://nucwed.aus.aunty.abc.net.au/cm/rimage/7125904-3x2-large.png?v=3',
+            width: 700
+          },
+          {
+            height: 213,
+            ratio: '3x4',
+            size: 3219,
+            url: 'http://nucwed.aus.aunty.abc.net.au/cm/rimage/7125904-3x4-thumbnail.png?v=3',
+            width: 160
+          },
+          {
+            height: 627,
+            ratio: '3x4',
+            size: 6930,
+            url: 'http://nucwed.aus.aunty.abc.net.au/cm/rimage/7125904-3x4-large.png?v=3',
+            width: 469
+          },
+          {
+            height: 120,
+            ratio: '4x3',
+            size: 1821,
+            url: 'http://nucwed.aus.aunty.abc.net.au/cm/rimage/7125904-4x3-thumbnail.png?v=3',
+            width: 160
+          },
+          {
+            height: 525,
+            ratio: '4x3',
+            size: 11173,
+            url: 'http://nucwed.aus.aunty.abc.net.au/cm/rimage/7125904-4x3-large.png?v=3',
+            width: 700
+          },
+          {
+            height: 485,
+            ratio: '16x9',
+            url: 'http://nucwed.aus.aunty.abc.net.au/cm/rimage/7125904-16x9-xlarge.png?v=3',
+            width: 862
+          },
+          {
+            height: 627,
+            ratio: '1x1',
+            url: 'http://nucwed.aus.aunty.abc.net.au/cm/rimage/7125904-1x1-xlarge.png?v=3',
+            width: 627
+          },
+          {
+            height: 575,
+            ratio: '3x2',
+            url: 'http://nucwed.aus.aunty.abc.net.au/cm/rimage/7125904-3x2-xlarge.png?v=3',
+            width: 862
+          },
+          {
+            height: 627,
+            ratio: '3x4',
+            url: 'http://nucwed.aus.aunty.abc.net.au/cm/rimage/7125904-3x4-xlarge.png?v=3',
+            width: 469
+          },
+          {
+            height: 627,
+            ratio: '4x3',
+            url: 'http://nucwed.aus.aunty.abc.net.au/cm/rimage/7125904-4x3-xlarge.png?v=3',
+            width: 836
+          }
+        ],
+        images: {
+          '16x9': 'http://nucwed.aus.aunty.abc.net.au/cm/rimage/7125904-16x9-xlarge.png?v=3',
+          '1x1': 'http://nucwed.aus.aunty.abc.net.au/cm/rimage/7125904-1x1-large.png?v=3',
+          '3x2': 'http://nucwed.aus.aunty.abc.net.au/cm/rimage/7125904-3x2-xlarge.png?v=3',
+          '3x4': 'http://nucwed.aus.aunty.abc.net.au/cm/rimage/7125904-3x4-large.png?v=3',
+          '4x3': 'http://nucwed.aus.aunty.abc.net.au/cm/rimage/7125904-4x3-xlarge.png?v=3'
+        }
+      }
+    }
+  },
+  title: 'Placeholder Image',
+  titleAlt: { lg: 'Placeholder Image', md: 'Placeholder Image', sm: 'Placeholder Image' }
+};
+
+export const result = {
+  cmid: '7125904',
+  title: 'Placeholder Image',
+  alt: 'Placeholder Image alt text',
+  caption: 'Placeholder image caption text',
+  attribution: 'Supplied: image generator',
+  canonicalURL: 'http://nucwed.aus.aunty.abc.net.au/news/2017-01-10/placeholder-image/7125904',
+  renditions: [
+    {
+      height: 90,
+      ratio: '16x9',
+      isUndersizedBinary: false,
+      url: 'http://nucwed.aus.aunty.abc.net.au/cm/rimage/7125904-16x9-thumbnail.png?v=3',
+      width: 160
+    },
+    {
+      height: 394,
+      ratio: '16x9',
+      isUndersizedBinary: false,
+      url: 'http://nucwed.aus.aunty.abc.net.au/cm/rimage/7125904-16x9-large.png?v=3',
+      width: 700
+    },
+    {
+      height: 160,
+      ratio: '1x1',
+      isUndersizedBinary: false,
+      url: 'http://nucwed.aus.aunty.abc.net.au/cm/rimage/7125904-1x1-thumbnail.png?v=3',
+      width: 160
+    },
+    {
+      height: 627,
+      ratio: '1x1',
+      isUndersizedBinary: false,
+      url: 'http://nucwed.aus.aunty.abc.net.au/cm/rimage/7125904-1x1-large.png?v=3',
+      width: 627
+    },
+    {
+      height: 107,
+      ratio: '3x2',
+      isUndersizedBinary: false,
+      url: 'http://nucwed.aus.aunty.abc.net.au/cm/rimage/7125904-3x2-thumbnail.png?v=3',
+      width: 160
+    },
+    {
+      height: 467,
+      ratio: '3x2',
+      isUndersizedBinary: false,
+      url: 'http://nucwed.aus.aunty.abc.net.au/cm/rimage/7125904-3x2-large.png?v=3',
+      width: 700
+    },
+    {
+      height: 213,
+      ratio: '3x4',
+      isUndersizedBinary: false,
+      url: 'http://nucwed.aus.aunty.abc.net.au/cm/rimage/7125904-3x4-thumbnail.png?v=3',
+      width: 160
+    },
+    {
+      height: 627,
+      ratio: '3x4',
+      isUndersizedBinary: false,
+      url: 'http://nucwed.aus.aunty.abc.net.au/cm/rimage/7125904-3x4-large.png?v=3',
+      width: 469
+    },
+    {
+      height: 120,
+      ratio: '4x3',
+      isUndersizedBinary: false,
+      url: 'http://nucwed.aus.aunty.abc.net.au/cm/rimage/7125904-4x3-thumbnail.png?v=3',
+      width: 160
+    },
+    {
+      height: 525,
+      ratio: '4x3',
+      isUndersizedBinary: false,
+      url: 'http://nucwed.aus.aunty.abc.net.au/cm/rimage/7125904-4x3-large.png?v=3',
+      width: 700
+    },
+    {
+      height: 485,
+      ratio: '16x9',
+      isUndersizedBinary: false,
+      url: 'http://nucwed.aus.aunty.abc.net.au/cm/rimage/7125904-16x9-xlarge.png?v=3',
+      width: 862
+    },
+    {
+      height: 627,
+      ratio: '1x1',
+      isUndersizedBinary: false,
+      url: 'http://nucwed.aus.aunty.abc.net.au/cm/rimage/7125904-1x1-xlarge.png?v=3',
+      width: 627
+    },
+    {
+      height: 575,
+      ratio: '3x2',
+      isUndersizedBinary: false,
+      url: 'http://nucwed.aus.aunty.abc.net.au/cm/rimage/7125904-3x2-xlarge.png?v=3',
+      width: 862
+    },
+    {
+      height: 627,
+      ratio: '3x4',
+      isUndersizedBinary: false,
+      url: 'http://nucwed.aus.aunty.abc.net.au/cm/rimage/7125904-3x4-xlarge.png?v=3',
+      width: 469
+    },
+    {
+      height: 627,
+      ratio: '4x3',
+      isUndersizedBinary: false,
+      url: 'http://nucwed.aus.aunty.abc.net.au/cm/rimage/7125904-4x3-xlarge.png?v=3',
+      width: 836
+    }
+  ]
+};

--- a/src/test-data/v1-standard-proxy-title-update.ts
+++ b/src/test-data/v1-standard-proxy-title-update.ts
@@ -1,0 +1,249 @@
+export const input = {
+  _links: { self: { href: '/api/v1/content/coremedia/imageproxy/13212876' } },
+  alt: 'Placeholder image proxy',
+  attribution: 'Supplied: image generator',
+  byLine: { type: 'element', tagname: 'p', children: [{ type: 'text', content: 'Supplied: image generator' }] },
+  canonicalURL: 'http://nucwed.aus.aunty.abc.net.au/news/2021-03-04/placeholder-image-proxy/13212876',
+  contentSource: 'coremedia',
+  dates: {
+    displayPublished: '2021-03-04T01:09:04+00:00',
+    published: '2021-03-04T01:09:04+00:00',
+    updated: '2021-03-03T06:25:10+00:00'
+  },
+  docType: 'ImageProxy',
+  id: '13212876',
+  lang: 'en',
+  media: {
+    image: {
+      primary: {
+        complete: [
+          {
+            height: 90,
+            ratio: '16x9',
+            size: 1617,
+            url: 'http://nucwed.aus.aunty.abc.net.au/cm/rimage/7125904-16x9-thumbnail.png?v=3',
+            width: 160
+          },
+          {
+            height: 394,
+            ratio: '16x9',
+            size: 9253,
+            url: 'http://nucwed.aus.aunty.abc.net.au/cm/rimage/7125904-16x9-large.png?v=3',
+            width: 700
+          },
+          {
+            height: 160,
+            ratio: '1x1',
+            size: 2443,
+            url: 'http://nucwed.aus.aunty.abc.net.au/cm/rimage/7125904-1x1-thumbnail.png?v=3',
+            width: 160
+          },
+          {
+            height: 627,
+            ratio: '1x1',
+            size: 7340,
+            url: 'http://nucwed.aus.aunty.abc.net.au/cm/rimage/7125904-1x1-large.png?v=3',
+            width: 627
+          },
+          {
+            height: 107,
+            ratio: '3x2',
+            size: 1657,
+            url: 'http://nucwed.aus.aunty.abc.net.au/cm/rimage/7125904-3x2-thumbnail.png?v=3',
+            width: 160
+          },
+          {
+            height: 467,
+            ratio: '3x2',
+            size: 9589,
+            url: 'http://nucwed.aus.aunty.abc.net.au/cm/rimage/7125904-3x2-large.png?v=3',
+            width: 700
+          },
+          {
+            height: 213,
+            ratio: '3x4',
+            size: 3219,
+            url: 'http://nucwed.aus.aunty.abc.net.au/cm/rimage/7125904-3x4-thumbnail.png?v=3',
+            width: 160
+          },
+          {
+            height: 627,
+            ratio: '3x4',
+            size: 6930,
+            url: 'http://nucwed.aus.aunty.abc.net.au/cm/rimage/7125904-3x4-large.png?v=3',
+            width: 469
+          },
+          {
+            height: 120,
+            ratio: '4x3',
+            size: 1821,
+            url: 'http://nucwed.aus.aunty.abc.net.au/cm/rimage/7125904-4x3-thumbnail.png?v=3',
+            width: 160
+          },
+          {
+            height: 525,
+            ratio: '4x3',
+            size: 11173,
+            url: 'http://nucwed.aus.aunty.abc.net.au/cm/rimage/7125904-4x3-large.png?v=3',
+            width: 700
+          },
+          {
+            height: 485,
+            ratio: '16x9',
+            url: 'http://nucwed.aus.aunty.abc.net.au/cm/rimage/7125904-16x9-xlarge.png?v=3',
+            width: 862
+          },
+          {
+            height: 627,
+            ratio: '1x1',
+            url: 'http://nucwed.aus.aunty.abc.net.au/cm/rimage/7125904-1x1-xlarge.png?v=3',
+            width: 627
+          },
+          {
+            height: 575,
+            ratio: '3x2',
+            url: 'http://nucwed.aus.aunty.abc.net.au/cm/rimage/7125904-3x2-xlarge.png?v=3',
+            width: 862
+          },
+          {
+            height: 627,
+            ratio: '3x4',
+            url: 'http://nucwed.aus.aunty.abc.net.au/cm/rimage/7125904-3x4-xlarge.png?v=3',
+            width: 469
+          },
+          {
+            height: 627,
+            ratio: '4x3',
+            url: 'http://nucwed.aus.aunty.abc.net.au/cm/rimage/7125904-4x3-xlarge.png?v=3',
+            width: 836
+          }
+        ],
+        images: {
+          '16x9': 'http://nucwed.aus.aunty.abc.net.au/cm/rimage/7125904-16x9-xlarge.png?v=3',
+          '1x1': 'http://nucwed.aus.aunty.abc.net.au/cm/rimage/7125904-1x1-large.png?v=3',
+          '3x2': 'http://nucwed.aus.aunty.abc.net.au/cm/rimage/7125904-3x2-xlarge.png?v=3',
+          '3x4': 'http://nucwed.aus.aunty.abc.net.au/cm/rimage/7125904-3x4-large.png?v=3',
+          '4x3': 'http://nucwed.aus.aunty.abc.net.au/cm/rimage/7125904-4x3-xlarge.png?v=3'
+        }
+      }
+    }
+  },
+  title: 'Placeholder image proxy',
+  titleAlt: { lg: 'Placeholder image proxy', md: 'Placeholder image proxy', sm: 'Placeholder Image' }
+};
+
+export const result = {
+  cmid: '13212876',
+  title: 'Placeholder image proxy',
+  alt: 'Placeholder image proxy',
+  caption: undefined,
+  attribution: 'Supplied: image generator',
+  canonicalURL: 'http://nucwed.aus.aunty.abc.net.au/news/2021-03-04/placeholder-image-proxy/13212876',
+  renditions: [
+    {
+      height: 90,
+      ratio: '16x9',
+      isUndersizedBinary: false,
+      url: 'http://nucwed.aus.aunty.abc.net.au/cm/rimage/7125904-16x9-thumbnail.png?v=3',
+      width: 160
+    },
+    {
+      height: 394,
+      ratio: '16x9',
+      isUndersizedBinary: false,
+      url: 'http://nucwed.aus.aunty.abc.net.au/cm/rimage/7125904-16x9-large.png?v=3',
+      width: 700
+    },
+    {
+      height: 160,
+      ratio: '1x1',
+      isUndersizedBinary: false,
+      url: 'http://nucwed.aus.aunty.abc.net.au/cm/rimage/7125904-1x1-thumbnail.png?v=3',
+      width: 160
+    },
+    {
+      height: 627,
+      ratio: '1x1',
+      isUndersizedBinary: false,
+      url: 'http://nucwed.aus.aunty.abc.net.au/cm/rimage/7125904-1x1-large.png?v=3',
+      width: 627
+    },
+    {
+      height: 107,
+      ratio: '3x2',
+      isUndersizedBinary: false,
+      url: 'http://nucwed.aus.aunty.abc.net.au/cm/rimage/7125904-3x2-thumbnail.png?v=3',
+      width: 160
+    },
+    {
+      height: 467,
+      ratio: '3x2',
+      isUndersizedBinary: false,
+      url: 'http://nucwed.aus.aunty.abc.net.au/cm/rimage/7125904-3x2-large.png?v=3',
+      width: 700
+    },
+    {
+      height: 213,
+      ratio: '3x4',
+      isUndersizedBinary: false,
+      url: 'http://nucwed.aus.aunty.abc.net.au/cm/rimage/7125904-3x4-thumbnail.png?v=3',
+      width: 160
+    },
+    {
+      height: 627,
+      ratio: '3x4',
+      isUndersizedBinary: false,
+      url: 'http://nucwed.aus.aunty.abc.net.au/cm/rimage/7125904-3x4-large.png?v=3',
+      width: 469
+    },
+    {
+      height: 120,
+      ratio: '4x3',
+      isUndersizedBinary: false,
+      url: 'http://nucwed.aus.aunty.abc.net.au/cm/rimage/7125904-4x3-thumbnail.png?v=3',
+      width: 160
+    },
+    {
+      height: 525,
+      ratio: '4x3',
+      isUndersizedBinary: false,
+      url: 'http://nucwed.aus.aunty.abc.net.au/cm/rimage/7125904-4x3-large.png?v=3',
+      width: 700
+    },
+    {
+      height: 485,
+      ratio: '16x9',
+      isUndersizedBinary: false,
+      url: 'http://nucwed.aus.aunty.abc.net.au/cm/rimage/7125904-16x9-xlarge.png?v=3',
+      width: 862
+    },
+    {
+      height: 627,
+      ratio: '1x1',
+      isUndersizedBinary: false,
+      url: 'http://nucwed.aus.aunty.abc.net.au/cm/rimage/7125904-1x1-xlarge.png?v=3',
+      width: 627
+    },
+    {
+      height: 575,
+      ratio: '3x2',
+      isUndersizedBinary: false,
+      url: 'http://nucwed.aus.aunty.abc.net.au/cm/rimage/7125904-3x2-xlarge.png?v=3',
+      width: 862
+    },
+    {
+      height: 627,
+      ratio: '3x4',
+      isUndersizedBinary: false,
+      url: 'http://nucwed.aus.aunty.abc.net.au/cm/rimage/7125904-3x4-xlarge.png?v=3',
+      width: 469
+    },
+    {
+      height: 627,
+      ratio: '4x3',
+      isUndersizedBinary: false,
+      url: 'http://nucwed.aus.aunty.abc.net.au/cm/rimage/7125904-4x3-xlarge.png?v=3',
+      width: 836
+    }
+  ]
+};

--- a/src/test-data/v2-standard-complete.ts
+++ b/src/test-data/v2-standard-complete.ts
@@ -1,0 +1,475 @@
+export const input = {
+  _links: { self: { href: '/api/v2/content/coremedia/image/100016478' } },
+  alt: 'A placeholder image with multiple renditions',
+  byLine: {
+    json: {
+      type: 'element',
+      tagname: 'div',
+      parameters: {
+        xmlns: 'http://www.coremedia.com/2003/richtext-1.0',
+        'xmlns:xlink': 'http://www.w3.org/1999/xlink'
+      },
+      children: [
+        {
+          type: 'element',
+          tagname: 'p',
+          children: [{ type: 'text', content: 'Supplied: Image generator' }]
+        }
+      ]
+    },
+    plain: 'Supplied: Image generator'
+  },
+  canonicalURI: '/news/2021-03-04/placeholder-example-image/100016478',
+  canonicalURL: 'https://www.abc.net.au/news/2021-03-04/placeholder-example-image/100016478',
+  caption: 'This is the caption on a placeholder image.',
+  contentSource: 'coremedia',
+  dates: {
+    displayPublished: '2021-03-04T01:57:19+00:00',
+    published: '2021-03-04T01:57:19+00:00',
+    updated: '2021-03-04T01:05:48+00:00'
+  },
+  docType: 'Image',
+  id: '100016478',
+  lang: 'en',
+  media: {
+    image: {
+      primary: {
+        binaryKey: 'c8904ae9d0c567b6fc91e0b3217bd8e7',
+        complete: [
+          {
+            cropHeight: 467,
+            cropWidth: 700,
+            height: 575,
+            ratio: '3x2',
+            url:
+              'https://preview-uat.wcms-np.abc-cdn.net.au/c8904ae9d0c567b6fc91e0b3217bd8e7?impolicy=wcms_crop_resize&cropH=467&cropW=700&xPos=0&yPos=0&width=862&height=575',
+            width: 862,
+            x: 0,
+            y: 0
+          },
+          {
+            cropHeight: 467,
+            cropWidth: 623,
+            height: 647,
+            ratio: '4x3',
+            url:
+              'https://preview-uat.wcms-np.abc-cdn.net.au/c8904ae9d0c567b6fc91e0b3217bd8e7?impolicy=wcms_crop_resize&cropH=467&cropW=623&xPos=39&yPos=0&width=862&height=647',
+            width: 862,
+            x: 39,
+            y: 0
+          },
+          {
+            cropHeight: 467,
+            cropWidth: 467,
+            height: 862,
+            ratio: '1x1',
+            url:
+              'https://preview-uat.wcms-np.abc-cdn.net.au/c8904ae9d0c567b6fc91e0b3217bd8e7?impolicy=wcms_crop_resize&cropH=467&cropW=467&xPos=117&yPos=0&width=862&height=862',
+            width: 862,
+            x: 117,
+            y: 0
+          },
+          {
+            cropHeight: 394,
+            cropWidth: 700,
+            height: 485,
+            ratio: '16x9',
+            url:
+              'https://preview-uat.wcms-np.abc-cdn.net.au/c8904ae9d0c567b6fc91e0b3217bd8e7?impolicy=wcms_crop_resize&cropH=394&cropW=700&xPos=0&yPos=37&width=862&height=485',
+            width: 862,
+            x: 0,
+            y: 37
+          },
+          {
+            cropHeight: 467,
+            cropWidth: 350,
+            height: 1149,
+            ratio: '3x4',
+            url:
+              'https://preview-uat.wcms-np.abc-cdn.net.au/c8904ae9d0c567b6fc91e0b3217bd8e7?impolicy=wcms_crop_resize&cropH=467&cropW=350&xPos=175&yPos=0&width=862&height=1149',
+            width: 862,
+            x: 175,
+            y: 0
+          },
+          {
+            cropHeight: 467,
+            cropWidth: 700,
+            height: 107,
+            ratio: '3x2',
+            url:
+              'https://preview-uat.wcms-np.abc-cdn.net.au/c8904ae9d0c567b6fc91e0b3217bd8e7?impolicy=wcms_crop_resize&cropH=467&cropW=700&xPos=0&yPos=0&width=160&height=107',
+            width: 160,
+            x: 0,
+            y: 0
+          },
+          {
+            cropHeight: 467,
+            cropWidth: 623,
+            height: 120,
+            ratio: '4x3',
+            url:
+              'https://preview-uat.wcms-np.abc-cdn.net.au/c8904ae9d0c567b6fc91e0b3217bd8e7?impolicy=wcms_crop_resize&cropH=467&cropW=623&xPos=39&yPos=0&width=160&height=120',
+            width: 160,
+            x: 39,
+            y: 0
+          },
+          {
+            cropHeight: 467,
+            cropWidth: 467,
+            height: 160,
+            ratio: '1x1',
+            url:
+              'https://preview-uat.wcms-np.abc-cdn.net.au/c8904ae9d0c567b6fc91e0b3217bd8e7?impolicy=wcms_crop_resize&cropH=467&cropW=467&xPos=117&yPos=0&width=160&height=160',
+            width: 160,
+            x: 117,
+            y: 0
+          },
+          {
+            cropHeight: 394,
+            cropWidth: 700,
+            height: 90,
+            ratio: '16x9',
+            url:
+              'https://preview-uat.wcms-np.abc-cdn.net.au/c8904ae9d0c567b6fc91e0b3217bd8e7?impolicy=wcms_crop_resize&cropH=394&cropW=700&xPos=0&yPos=37&width=160&height=90',
+            width: 160,
+            x: 0,
+            y: 37
+          },
+          {
+            cropHeight: 467,
+            cropWidth: 350,
+            height: 213,
+            ratio: '3x4',
+            url:
+              'https://preview-uat.wcms-np.abc-cdn.net.au/c8904ae9d0c567b6fc91e0b3217bd8e7?impolicy=wcms_crop_resize&cropH=467&cropW=350&xPos=175&yPos=0&width=160&height=213',
+            width: 160,
+            x: 175,
+            y: 0
+          }
+        ],
+        images: {
+          '16x9':
+            'https://preview-uat.wcms-np.abc-cdn.net.au/c8904ae9d0c567b6fc91e0b3217bd8e7?impolicy=wcms_crop_resize&cropH=394&cropW=700&xPos=0&yPos=37&width=862&height=485',
+          '1x1':
+            'https://preview-uat.wcms-np.abc-cdn.net.au/c8904ae9d0c567b6fc91e0b3217bd8e7?impolicy=wcms_crop_resize&cropH=467&cropW=467&xPos=117&yPos=0&width=862&height=862',
+          '3x2':
+            'https://preview-uat.wcms-np.abc-cdn.net.au/c8904ae9d0c567b6fc91e0b3217bd8e7?impolicy=wcms_crop_resize&cropH=467&cropW=700&xPos=0&yPos=0&width=862&height=575',
+          '3x4':
+            'https://preview-uat.wcms-np.abc-cdn.net.au/c8904ae9d0c567b6fc91e0b3217bd8e7?impolicy=wcms_crop_resize&cropH=467&cropW=350&xPos=175&yPos=0&width=862&height=1149',
+          '4x3':
+            'https://preview-uat.wcms-np.abc-cdn.net.au/c8904ae9d0c567b6fc91e0b3217bd8e7?impolicy=wcms_crop_resize&cropH=467&cropW=623&xPos=39&yPos=0&width=862&height=647'
+        },
+        notChildFriendly: false,
+        ratios: {
+          '16x9': { cropHeight: 394, cropWidth: 700, x: 0, y: 37 },
+          '1x1': { cropHeight: 467, cropWidth: 467, x: 117, y: 0 },
+          '3x2': { cropHeight: 467, cropWidth: 700, x: 0, y: 0 },
+          '3x4': { cropHeight: 467, cropWidth: 350, x: 175, y: 0 },
+          '4x3': { cropHeight: 467, cropWidth: 623, x: 39, y: 0 }
+        }
+      }
+    }
+  },
+  synopsis: 'This is the regular teaser text on a placeholder image.',
+  synopsisAlt: {
+    lg: 'This is the regular teaser text on a placeholder image.',
+    sm: 'Short teaser text on a placeholder image.'
+  },
+  title: 'Placeholder example image',
+  titleAlt: {
+    lg: 'Placeholder example image',
+    md: 'A regular teaser title on a placeholder image with multiple renditions',
+    sm: 'A short teaser title on a placeholder image'
+  }
+};
+
+export const result = {
+  cmid: '100016478',
+  title: 'Placeholder example image',
+  alt: 'A placeholder image with multiple renditions',
+  caption: 'This is the caption on a placeholder image.',
+  attribution: 'Supplied: Image generator',
+  canonicalURL: 'https://www.abc.net.au/news/2021-03-04/placeholder-example-image/100016478',
+  renditions: [
+    {
+      url:
+        'https://preview-uat.wcms-np.abc-cdn.net.au/c8904ae9d0c567b6fc91e0b3217bd8e7?impolicy=wcms_crop_resize&cropH=394&cropW=700&xPos=0&yPos=37&width=160&height=90',
+      width: 160,
+      height: 90,
+      ratio: '16x9',
+      isUndersizedBinary: false
+    },
+    {
+      url:
+        'https://preview-uat.wcms-np.abc-cdn.net.au/c8904ae9d0c567b6fc91e0b3217bd8e7?impolicy=wcms_crop_resize&cropH=394&cropW=700&xPos=0&yPos=37&width=240&height=135',
+      width: 240,
+      height: 135,
+      ratio: '16x9',
+      isUndersizedBinary: false
+    },
+    {
+      url:
+        'https://preview-uat.wcms-np.abc-cdn.net.au/c8904ae9d0c567b6fc91e0b3217bd8e7?impolicy=wcms_crop_resize&cropH=394&cropW=700&xPos=0&yPos=37&width=480&height=270',
+      width: 480,
+      height: 270,
+      ratio: '16x9',
+      isUndersizedBinary: false
+    },
+    {
+      url:
+        'https://preview-uat.wcms-np.abc-cdn.net.au/c8904ae9d0c567b6fc91e0b3217bd8e7?impolicy=wcms_crop_resize&cropH=394&cropW=700&xPos=0&yPos=37&width=700&height=394',
+      width: 700,
+      height: 394,
+      ratio: '16x9',
+      isUndersizedBinary: false
+    },
+    {
+      url:
+        'https://preview-uat.wcms-np.abc-cdn.net.au/c8904ae9d0c567b6fc91e0b3217bd8e7?impolicy=wcms_crop_resize&cropH=394&cropW=700&xPos=0&yPos=37&width=940&height=529',
+      width: 940,
+      height: 529,
+      ratio: '16x9',
+      isUndersizedBinary: true
+    },
+    {
+      url:
+        'https://preview-uat.wcms-np.abc-cdn.net.au/c8904ae9d0c567b6fc91e0b3217bd8e7?impolicy=wcms_crop_resize&cropH=394&cropW=700&xPos=0&yPos=37&width=1400&height=788',
+      width: 1400,
+      height: 788,
+      ratio: '16x9',
+      isUndersizedBinary: true
+    },
+    {
+      url:
+        'https://preview-uat.wcms-np.abc-cdn.net.au/c8904ae9d0c567b6fc91e0b3217bd8e7?impolicy=wcms_crop_resize&cropH=394&cropW=700&xPos=0&yPos=37&width=2150&height=1210',
+      width: 2150,
+      height: 1210,
+      ratio: '16x9',
+      isUndersizedBinary: true
+    },
+    {
+      url:
+        'https://preview-uat.wcms-np.abc-cdn.net.au/c8904ae9d0c567b6fc91e0b3217bd8e7?impolicy=wcms_crop_resize&cropH=467&cropW=467&xPos=117&yPos=0&width=160&height=160',
+      width: 160,
+      height: 160,
+      ratio: '1x1',
+      isUndersizedBinary: false
+    },
+    {
+      url:
+        'https://preview-uat.wcms-np.abc-cdn.net.au/c8904ae9d0c567b6fc91e0b3217bd8e7?impolicy=wcms_crop_resize&cropH=467&cropW=467&xPos=117&yPos=0&width=240&height=240',
+      width: 240,
+      height: 240,
+      ratio: '1x1',
+      isUndersizedBinary: false
+    },
+    {
+      url:
+        'https://preview-uat.wcms-np.abc-cdn.net.au/c8904ae9d0c567b6fc91e0b3217bd8e7?impolicy=wcms_crop_resize&cropH=467&cropW=467&xPos=117&yPos=0&width=480&height=480',
+      width: 480,
+      height: 480,
+      ratio: '1x1',
+      isUndersizedBinary: true
+    },
+    {
+      url:
+        'https://preview-uat.wcms-np.abc-cdn.net.au/c8904ae9d0c567b6fc91e0b3217bd8e7?impolicy=wcms_crop_resize&cropH=467&cropW=467&xPos=117&yPos=0&width=700&height=700',
+      width: 700,
+      height: 700,
+      ratio: '1x1',
+      isUndersizedBinary: true
+    },
+    {
+      url:
+        'https://preview-uat.wcms-np.abc-cdn.net.au/c8904ae9d0c567b6fc91e0b3217bd8e7?impolicy=wcms_crop_resize&cropH=467&cropW=467&xPos=117&yPos=0&width=940&height=940',
+      width: 940,
+      height: 940,
+      ratio: '1x1',
+      isUndersizedBinary: true
+    },
+    {
+      url:
+        'https://preview-uat.wcms-np.abc-cdn.net.au/c8904ae9d0c567b6fc91e0b3217bd8e7?impolicy=wcms_crop_resize&cropH=467&cropW=467&xPos=117&yPos=0&width=1400&height=1400',
+      width: 1400,
+      height: 1400,
+      ratio: '1x1',
+      isUndersizedBinary: true
+    },
+    {
+      url:
+        'https://preview-uat.wcms-np.abc-cdn.net.au/c8904ae9d0c567b6fc91e0b3217bd8e7?impolicy=wcms_crop_resize&cropH=467&cropW=467&xPos=117&yPos=0&width=2150&height=2150',
+      width: 2150,
+      height: 2150,
+      ratio: '1x1',
+      isUndersizedBinary: true
+    },
+    {
+      url:
+        'https://preview-uat.wcms-np.abc-cdn.net.au/c8904ae9d0c567b6fc91e0b3217bd8e7?impolicy=wcms_crop_resize&cropH=467&cropW=700&xPos=0&yPos=0&width=160&height=107',
+      width: 160,
+      height: 107,
+      ratio: '3x2',
+      isUndersizedBinary: false
+    },
+    {
+      url:
+        'https://preview-uat.wcms-np.abc-cdn.net.au/c8904ae9d0c567b6fc91e0b3217bd8e7?impolicy=wcms_crop_resize&cropH=467&cropW=700&xPos=0&yPos=0&width=240&height=160',
+      width: 240,
+      height: 160,
+      ratio: '3x2',
+      isUndersizedBinary: false
+    },
+    {
+      url:
+        'https://preview-uat.wcms-np.abc-cdn.net.au/c8904ae9d0c567b6fc91e0b3217bd8e7?impolicy=wcms_crop_resize&cropH=467&cropW=700&xPos=0&yPos=0&width=480&height=320',
+      width: 480,
+      height: 320,
+      ratio: '3x2',
+      isUndersizedBinary: false
+    },
+    {
+      url:
+        'https://preview-uat.wcms-np.abc-cdn.net.au/c8904ae9d0c567b6fc91e0b3217bd8e7?impolicy=wcms_crop_resize&cropH=467&cropW=700&xPos=0&yPos=0&width=700&height=467',
+      width: 700,
+      height: 467,
+      ratio: '3x2',
+      isUndersizedBinary: false
+    },
+    {
+      url:
+        'https://preview-uat.wcms-np.abc-cdn.net.au/c8904ae9d0c567b6fc91e0b3217bd8e7?impolicy=wcms_crop_resize&cropH=467&cropW=700&xPos=0&yPos=0&width=940&height=627',
+      width: 940,
+      height: 627,
+      ratio: '3x2',
+      isUndersizedBinary: true
+    },
+    {
+      url:
+        'https://preview-uat.wcms-np.abc-cdn.net.au/c8904ae9d0c567b6fc91e0b3217bd8e7?impolicy=wcms_crop_resize&cropH=467&cropW=700&xPos=0&yPos=0&width=1400&height=934',
+      width: 1400,
+      height: 934,
+      ratio: '3x2',
+      isUndersizedBinary: true
+    },
+    {
+      url:
+        'https://preview-uat.wcms-np.abc-cdn.net.au/c8904ae9d0c567b6fc91e0b3217bd8e7?impolicy=wcms_crop_resize&cropH=467&cropW=700&xPos=0&yPos=0&width=2150&height=1434',
+      width: 2150,
+      height: 1434,
+      ratio: '3x2',
+      isUndersizedBinary: true
+    },
+    {
+      url:
+        'https://preview-uat.wcms-np.abc-cdn.net.au/c8904ae9d0c567b6fc91e0b3217bd8e7?impolicy=wcms_crop_resize&cropH=467&cropW=350&xPos=175&yPos=0&width=160&height=213',
+      width: 160,
+      height: 213,
+      ratio: '3x4',
+      isUndersizedBinary: false
+    },
+    {
+      url:
+        'https://preview-uat.wcms-np.abc-cdn.net.au/c8904ae9d0c567b6fc91e0b3217bd8e7?impolicy=wcms_crop_resize&cropH=467&cropW=350&xPos=175&yPos=0&width=240&height=320',
+      width: 240,
+      height: 320,
+      ratio: '3x4',
+      isUndersizedBinary: false
+    },
+    {
+      url:
+        'https://preview-uat.wcms-np.abc-cdn.net.au/c8904ae9d0c567b6fc91e0b3217bd8e7?impolicy=wcms_crop_resize&cropH=467&cropW=350&xPos=175&yPos=0&width=480&height=640',
+      width: 480,
+      height: 640,
+      ratio: '3x4',
+      isUndersizedBinary: true
+    },
+    {
+      url:
+        'https://preview-uat.wcms-np.abc-cdn.net.au/c8904ae9d0c567b6fc91e0b3217bd8e7?impolicy=wcms_crop_resize&cropH=467&cropW=350&xPos=175&yPos=0&width=700&height=934',
+      width: 700,
+      height: 934,
+      ratio: '3x4',
+      isUndersizedBinary: true
+    },
+    {
+      url:
+        'https://preview-uat.wcms-np.abc-cdn.net.au/c8904ae9d0c567b6fc91e0b3217bd8e7?impolicy=wcms_crop_resize&cropH=467&cropW=350&xPos=175&yPos=0&width=940&height=1254',
+      width: 940,
+      height: 1254,
+      ratio: '3x4',
+      isUndersizedBinary: true
+    },
+    {
+      url:
+        'https://preview-uat.wcms-np.abc-cdn.net.au/c8904ae9d0c567b6fc91e0b3217bd8e7?impolicy=wcms_crop_resize&cropH=467&cropW=350&xPos=175&yPos=0&width=1400&height=1868',
+      width: 1400,
+      height: 1868,
+      ratio: '3x4',
+      isUndersizedBinary: true
+    },
+    {
+      url:
+        'https://preview-uat.wcms-np.abc-cdn.net.au/c8904ae9d0c567b6fc91e0b3217bd8e7?impolicy=wcms_crop_resize&cropH=467&cropW=350&xPos=175&yPos=0&width=2150&height=2869',
+      width: 2150,
+      height: 2869,
+      ratio: '3x4',
+      isUndersizedBinary: true
+    },
+    {
+      url:
+        'https://preview-uat.wcms-np.abc-cdn.net.au/c8904ae9d0c567b6fc91e0b3217bd8e7?impolicy=wcms_crop_resize&cropH=467&cropW=623&xPos=39&yPos=0&width=160&height=120',
+      width: 160,
+      height: 120,
+      ratio: '4x3',
+      isUndersizedBinary: false
+    },
+    {
+      url:
+        'https://preview-uat.wcms-np.abc-cdn.net.au/c8904ae9d0c567b6fc91e0b3217bd8e7?impolicy=wcms_crop_resize&cropH=467&cropW=623&xPos=39&yPos=0&width=240&height=180',
+      width: 240,
+      height: 180,
+      ratio: '4x3',
+      isUndersizedBinary: false
+    },
+    {
+      url:
+        'https://preview-uat.wcms-np.abc-cdn.net.au/c8904ae9d0c567b6fc91e0b3217bd8e7?impolicy=wcms_crop_resize&cropH=467&cropW=623&xPos=39&yPos=0&width=480&height=360',
+      width: 480,
+      height: 360,
+      ratio: '4x3',
+      isUndersizedBinary: false
+    },
+    {
+      url:
+        'https://preview-uat.wcms-np.abc-cdn.net.au/c8904ae9d0c567b6fc91e0b3217bd8e7?impolicy=wcms_crop_resize&cropH=467&cropW=623&xPos=39&yPos=0&width=700&height=525',
+      width: 700,
+      height: 525,
+      ratio: '4x3',
+      isUndersizedBinary: true
+    },
+    {
+      url:
+        'https://preview-uat.wcms-np.abc-cdn.net.au/c8904ae9d0c567b6fc91e0b3217bd8e7?impolicy=wcms_crop_resize&cropH=467&cropW=623&xPos=39&yPos=0&width=940&height=705',
+      width: 940,
+      height: 705,
+      ratio: '4x3',
+      isUndersizedBinary: true
+    },
+    {
+      url:
+        'https://preview-uat.wcms-np.abc-cdn.net.au/c8904ae9d0c567b6fc91e0b3217bd8e7?impolicy=wcms_crop_resize&cropH=467&cropW=623&xPos=39&yPos=0&width=1400&height=1049',
+      width: 1400,
+      height: 1049,
+      ratio: '4x3',
+      isUndersizedBinary: true
+    },
+    {
+      url:
+        'https://preview-uat.wcms-np.abc-cdn.net.au/c8904ae9d0c567b6fc91e0b3217bd8e7?impolicy=wcms_crop_resize&cropH=467&cropW=623&xPos=39&yPos=0&width=2150&height=1612',
+      width: 2150,
+      height: 1612,
+      ratio: '4x3',
+      isUndersizedBinary: true
+    }
+  ]
+};

--- a/src/test-data/v2-standard-proxy.ts
+++ b/src/test-data/v2-standard-proxy.ts
@@ -1,0 +1,470 @@
+export const input = {
+  _links: { self: { href: '/api/v2/content/coremedia/imageproxy/100024108' } },
+  alt: 'A placeholder image with multiple renditions',
+  byLine: {
+    json: {
+      type: 'element',
+      tagname: 'div',
+      parameters: {
+        xmlns: 'http://www.coremedia.com/2003/richtext-1.0',
+        'xmlns:xlink': 'http://www.w3.org/1999/xlink'
+      },
+      children: [{ type: 'element', tagname: 'p', children: [{ type: 'text', content: 'Supplied: Image generator' }] }]
+    },
+    plain: 'Supplied: Image generator'
+  },
+  canonicalURI: '/news/2021-03-04/placeholder-example-image-standard-1-/100024108',
+  canonicalURL: 'https://www.abc.net.au/news/2021-03-04/placeholder-example-image-standard-1-/100024108',
+  caption: 'This is the caption on a placeholder image.',
+  contentSource: 'coremedia',
+  dates: {
+    displayPublished: '2021-03-04T05:52:03+00:00',
+    published: '2021-03-04T05:52:03+00:00',
+    updated: '2021-03-04T05:48:52+00:00'
+  },
+  docType: 'ImageProxy',
+  id: '100024108',
+  lang: 'en',
+  media: {
+    image: {
+      primary: {
+        binaryKey: 'c8904ae9d0c567b6fc91e0b3217bd8e7',
+        complete: [
+          {
+            cropHeight: 467,
+            cropWidth: 700,
+            height: 107,
+            ratio: '3x2',
+            url:
+              'https://preview-uat.wcms-np.abc-cdn.net.au/c8904ae9d0c567b6f…esize&cropH=467&cropW=700&xPos=0&yPos=0&width=160&height=107',
+            width: 160,
+            x: 0,
+            y: 0
+          },
+          {
+            cropHeight: 467,
+            cropWidth: 623,
+            height: 120,
+            ratio: '4x3',
+            url:
+              'https://preview-uat.wcms-np.abc-cdn.net.au/c8904ae9d0c567b6f…size&cropH=467&cropW=623&xPos=39&yPos=0&width=160&height=120',
+            width: 160,
+            x: 39,
+            y: 0
+          },
+          {
+            cropHeight: 467,
+            cropWidth: 467,
+            height: 160,
+            ratio: '1x1',
+            url:
+              'https://preview-uat.wcms-np.abc-cdn.net.au/c8904ae9d0c567b6f…ize&cropH=467&cropW=467&xPos=117&yPos=0&width=160&height=160',
+            width: 160,
+            x: 117,
+            y: 0
+          },
+          {
+            cropHeight: 394,
+            cropWidth: 700,
+            height: 90,
+            ratio: '16x9',
+            url:
+              'https://preview-uat.wcms-np.abc-cdn.net.au/c8904ae9d0c567b6f…esize&cropH=394&cropW=700&xPos=0&yPos=37&width=160&height=90',
+            width: 160,
+            x: 0,
+            y: 37
+          },
+          {
+            cropHeight: 467,
+            cropWidth: 350,
+            height: 213,
+            ratio: '3x4',
+            url:
+              'https://preview-uat.wcms-np.abc-cdn.net.au/c8904ae9d0c567b6f…ize&cropH=467&cropW=350&xPos=175&yPos=0&width=160&height=213',
+            width: 160,
+            x: 175,
+            y: 0
+          },
+          {
+            cropHeight: 467,
+            cropWidth: 700,
+            height: 575,
+            ratio: '3x2',
+            url:
+              'https://preview-uat.wcms-np.abc-cdn.net.au/c8904ae9d0c567b6f…esize&cropH=467&cropW=700&xPos=0&yPos=0&width=862&height=575',
+            width: 862,
+            x: 0,
+            y: 0
+          },
+          {
+            cropHeight: 467,
+            cropWidth: 623,
+            height: 647,
+            ratio: '4x3',
+            url:
+              'https://preview-uat.wcms-np.abc-cdn.net.au/c8904ae9d0c567b6f…size&cropH=467&cropW=623&xPos=39&yPos=0&width=862&height=647',
+            width: 862,
+            x: 39,
+            y: 0
+          },
+          {
+            cropHeight: 467,
+            cropWidth: 467,
+            height: 862,
+            ratio: '1x1',
+            url:
+              'https://preview-uat.wcms-np.abc-cdn.net.au/c8904ae9d0c567b6f…ize&cropH=467&cropW=467&xPos=117&yPos=0&width=862&height=862',
+            width: 862,
+            x: 117,
+            y: 0
+          },
+          {
+            cropHeight: 394,
+            cropWidth: 700,
+            height: 485,
+            ratio: '16x9',
+            url:
+              'https://preview-uat.wcms-np.abc-cdn.net.au/c8904ae9d0c567b6f…size&cropH=394&cropW=700&xPos=0&yPos=37&width=862&height=485',
+            width: 862,
+            x: 0,
+            y: 37
+          },
+          {
+            cropHeight: 467,
+            cropWidth: 350,
+            height: 1149,
+            ratio: '3x4',
+            url:
+              'https://preview-uat.wcms-np.abc-cdn.net.au/c8904ae9d0c567b6f…ze&cropH=467&cropW=350&xPos=175&yPos=0&width=862&height=1149',
+            width: 862,
+            x: 175,
+            y: 0
+          }
+        ],
+        images: {
+          '16x9':
+            'https://preview-uat.wcms-np.abc-cdn.net.au/c8904ae9d0c567b6f…size&cropH=394&cropW=700&xPos=0&yPos=37&width=862&height=485',
+          '1x1':
+            'https://preview-uat.wcms-np.abc-cdn.net.au/c8904ae9d0c567b6f…ize&cropH=467&cropW=467&xPos=117&yPos=0&width=862&height=862',
+          '3x2':
+            'https://preview-uat.wcms-np.abc-cdn.net.au/c8904ae9d0c567b6f…esize&cropH=467&cropW=700&xPos=0&yPos=0&width=862&height=575',
+          '3x4':
+            'https://preview-uat.wcms-np.abc-cdn.net.au/c8904ae9d0c567b6f…ze&cropH=467&cropW=350&xPos=175&yPos=0&width=862&height=1149',
+          '4x3':
+            'https://preview-uat.wcms-np.abc-cdn.net.au/c8904ae9d0c567b6f…size&cropH=467&cropW=623&xPos=39&yPos=0&width=862&height=647'
+        },
+        notChildFriendly: false,
+        ratios: {
+          '16x9': { cropHeight: 394, cropWidth: 700, x: 0, y: 37 },
+          '1x1': { cropHeight: 467, cropWidth: 467, x: 117, y: 0 },
+          '3x2': { cropHeight: 467, cropWidth: 700, x: 0, y: 0 },
+          '3x4': { cropHeight: 467, cropWidth: 350, x: 175, y: 0 },
+          '4x3': { cropHeight: 467, cropWidth: 623, x: 39, y: 0 }
+        }
+      }
+    }
+  },
+  notChildFriendly: false,
+  synopsis: 'This is the regular teaser text on a placeholder image.',
+  synopsisAlt: {
+    lg: 'This is the regular teaser text on a placeholder image.',
+    sm: 'Short teaser text on a placeholder image.'
+  },
+  title: 'Placeholder example image',
+  titleAlt: {
+    lg: 'Placeholder example image',
+    md: 'A regular teaser title on a placeholder image with multiple renditions',
+    sm: 'A short teaser title on a placeholder image'
+  }
+};
+
+export const result = {
+  cmid: '100024108',
+  title: 'Placeholder example image',
+  alt: 'A placeholder image with multiple renditions',
+  caption: 'This is the caption on a placeholder image.',
+  attribution: 'Supplied: Image generator',
+  canonicalURL: 'https://www.abc.net.au/news/2021-03-04/placeholder-example-image-standard-1-/100024108',
+  renditions: [
+    {
+      url:
+        'https://preview-uat.wcms-np.abc-cdn.net.au/c8904ae9d0c567b6fc91e0b3217bd8e7?impolicy=wcms_crop_resize&cropH=394&cropW=700&xPos=0&yPos=37&width=160&height=90',
+      width: 160,
+      height: 90,
+      ratio: '16x9',
+      isUndersizedBinary: false
+    },
+    {
+      url:
+        'https://preview-uat.wcms-np.abc-cdn.net.au/c8904ae9d0c567b6fc91e0b3217bd8e7?impolicy=wcms_crop_resize&cropH=394&cropW=700&xPos=0&yPos=37&width=240&height=135',
+      width: 240,
+      height: 135,
+      ratio: '16x9',
+      isUndersizedBinary: false
+    },
+    {
+      url:
+        'https://preview-uat.wcms-np.abc-cdn.net.au/c8904ae9d0c567b6fc91e0b3217bd8e7?impolicy=wcms_crop_resize&cropH=394&cropW=700&xPos=0&yPos=37&width=480&height=270',
+      width: 480,
+      height: 270,
+      ratio: '16x9',
+      isUndersizedBinary: false
+    },
+    {
+      url:
+        'https://preview-uat.wcms-np.abc-cdn.net.au/c8904ae9d0c567b6fc91e0b3217bd8e7?impolicy=wcms_crop_resize&cropH=394&cropW=700&xPos=0&yPos=37&width=700&height=394',
+      width: 700,
+      height: 394,
+      ratio: '16x9',
+      isUndersizedBinary: false
+    },
+    {
+      url:
+        'https://preview-uat.wcms-np.abc-cdn.net.au/c8904ae9d0c567b6fc91e0b3217bd8e7?impolicy=wcms_crop_resize&cropH=394&cropW=700&xPos=0&yPos=37&width=940&height=529',
+      width: 940,
+      height: 529,
+      ratio: '16x9',
+      isUndersizedBinary: true
+    },
+    {
+      url:
+        'https://preview-uat.wcms-np.abc-cdn.net.au/c8904ae9d0c567b6fc91e0b3217bd8e7?impolicy=wcms_crop_resize&cropH=394&cropW=700&xPos=0&yPos=37&width=1400&height=788',
+      width: 1400,
+      height: 788,
+      ratio: '16x9',
+      isUndersizedBinary: true
+    },
+    {
+      url:
+        'https://preview-uat.wcms-np.abc-cdn.net.au/c8904ae9d0c567b6fc91e0b3217bd8e7?impolicy=wcms_crop_resize&cropH=394&cropW=700&xPos=0&yPos=37&width=2150&height=1210',
+      width: 2150,
+      height: 1210,
+      ratio: '16x9',
+      isUndersizedBinary: true
+    },
+    {
+      url:
+        'https://preview-uat.wcms-np.abc-cdn.net.au/c8904ae9d0c567b6fc91e0b3217bd8e7?impolicy=wcms_crop_resize&cropH=467&cropW=467&xPos=117&yPos=0&width=160&height=160',
+      width: 160,
+      height: 160,
+      ratio: '1x1',
+      isUndersizedBinary: false
+    },
+    {
+      url:
+        'https://preview-uat.wcms-np.abc-cdn.net.au/c8904ae9d0c567b6fc91e0b3217bd8e7?impolicy=wcms_crop_resize&cropH=467&cropW=467&xPos=117&yPos=0&width=240&height=240',
+      width: 240,
+      height: 240,
+      ratio: '1x1',
+      isUndersizedBinary: false
+    },
+    {
+      url:
+        'https://preview-uat.wcms-np.abc-cdn.net.au/c8904ae9d0c567b6fc91e0b3217bd8e7?impolicy=wcms_crop_resize&cropH=467&cropW=467&xPos=117&yPos=0&width=480&height=480',
+      width: 480,
+      height: 480,
+      ratio: '1x1',
+      isUndersizedBinary: true
+    },
+    {
+      url:
+        'https://preview-uat.wcms-np.abc-cdn.net.au/c8904ae9d0c567b6fc91e0b3217bd8e7?impolicy=wcms_crop_resize&cropH=467&cropW=467&xPos=117&yPos=0&width=700&height=700',
+      width: 700,
+      height: 700,
+      ratio: '1x1',
+      isUndersizedBinary: true
+    },
+    {
+      url:
+        'https://preview-uat.wcms-np.abc-cdn.net.au/c8904ae9d0c567b6fc91e0b3217bd8e7?impolicy=wcms_crop_resize&cropH=467&cropW=467&xPos=117&yPos=0&width=940&height=940',
+      width: 940,
+      height: 940,
+      ratio: '1x1',
+      isUndersizedBinary: true
+    },
+    {
+      url:
+        'https://preview-uat.wcms-np.abc-cdn.net.au/c8904ae9d0c567b6fc91e0b3217bd8e7?impolicy=wcms_crop_resize&cropH=467&cropW=467&xPos=117&yPos=0&width=1400&height=1400',
+      width: 1400,
+      height: 1400,
+      ratio: '1x1',
+      isUndersizedBinary: true
+    },
+    {
+      url:
+        'https://preview-uat.wcms-np.abc-cdn.net.au/c8904ae9d0c567b6fc91e0b3217bd8e7?impolicy=wcms_crop_resize&cropH=467&cropW=467&xPos=117&yPos=0&width=2150&height=2150',
+      width: 2150,
+      height: 2150,
+      ratio: '1x1',
+      isUndersizedBinary: true
+    },
+    {
+      url:
+        'https://preview-uat.wcms-np.abc-cdn.net.au/c8904ae9d0c567b6fc91e0b3217bd8e7?impolicy=wcms_crop_resize&cropH=467&cropW=700&xPos=0&yPos=0&width=160&height=107',
+      width: 160,
+      height: 107,
+      ratio: '3x2',
+      isUndersizedBinary: false
+    },
+    {
+      url:
+        'https://preview-uat.wcms-np.abc-cdn.net.au/c8904ae9d0c567b6fc91e0b3217bd8e7?impolicy=wcms_crop_resize&cropH=467&cropW=700&xPos=0&yPos=0&width=240&height=160',
+      width: 240,
+      height: 160,
+      ratio: '3x2',
+      isUndersizedBinary: false
+    },
+    {
+      url:
+        'https://preview-uat.wcms-np.abc-cdn.net.au/c8904ae9d0c567b6fc91e0b3217bd8e7?impolicy=wcms_crop_resize&cropH=467&cropW=700&xPos=0&yPos=0&width=480&height=320',
+      width: 480,
+      height: 320,
+      ratio: '3x2',
+      isUndersizedBinary: false
+    },
+    {
+      url:
+        'https://preview-uat.wcms-np.abc-cdn.net.au/c8904ae9d0c567b6fc91e0b3217bd8e7?impolicy=wcms_crop_resize&cropH=467&cropW=700&xPos=0&yPos=0&width=700&height=467',
+      width: 700,
+      height: 467,
+      ratio: '3x2',
+      isUndersizedBinary: false
+    },
+    {
+      url:
+        'https://preview-uat.wcms-np.abc-cdn.net.au/c8904ae9d0c567b6fc91e0b3217bd8e7?impolicy=wcms_crop_resize&cropH=467&cropW=700&xPos=0&yPos=0&width=940&height=627',
+      width: 940,
+      height: 627,
+      ratio: '3x2',
+      isUndersizedBinary: true
+    },
+    {
+      url:
+        'https://preview-uat.wcms-np.abc-cdn.net.au/c8904ae9d0c567b6fc91e0b3217bd8e7?impolicy=wcms_crop_resize&cropH=467&cropW=700&xPos=0&yPos=0&width=1400&height=934',
+      width: 1400,
+      height: 934,
+      ratio: '3x2',
+      isUndersizedBinary: true
+    },
+    {
+      url:
+        'https://preview-uat.wcms-np.abc-cdn.net.au/c8904ae9d0c567b6fc91e0b3217bd8e7?impolicy=wcms_crop_resize&cropH=467&cropW=700&xPos=0&yPos=0&width=2150&height=1434',
+      width: 2150,
+      height: 1434,
+      ratio: '3x2',
+      isUndersizedBinary: true
+    },
+    {
+      url:
+        'https://preview-uat.wcms-np.abc-cdn.net.au/c8904ae9d0c567b6fc91e0b3217bd8e7?impolicy=wcms_crop_resize&cropH=467&cropW=350&xPos=175&yPos=0&width=160&height=213',
+      width: 160,
+      height: 213,
+      ratio: '3x4',
+      isUndersizedBinary: false
+    },
+    {
+      url:
+        'https://preview-uat.wcms-np.abc-cdn.net.au/c8904ae9d0c567b6fc91e0b3217bd8e7?impolicy=wcms_crop_resize&cropH=467&cropW=350&xPos=175&yPos=0&width=240&height=320',
+      width: 240,
+      height: 320,
+      ratio: '3x4',
+      isUndersizedBinary: false
+    },
+    {
+      url:
+        'https://preview-uat.wcms-np.abc-cdn.net.au/c8904ae9d0c567b6fc91e0b3217bd8e7?impolicy=wcms_crop_resize&cropH=467&cropW=350&xPos=175&yPos=0&width=480&height=640',
+      width: 480,
+      height: 640,
+      ratio: '3x4',
+      isUndersizedBinary: true
+    },
+    {
+      url:
+        'https://preview-uat.wcms-np.abc-cdn.net.au/c8904ae9d0c567b6fc91e0b3217bd8e7?impolicy=wcms_crop_resize&cropH=467&cropW=350&xPos=175&yPos=0&width=700&height=934',
+      width: 700,
+      height: 934,
+      ratio: '3x4',
+      isUndersizedBinary: true
+    },
+    {
+      url:
+        'https://preview-uat.wcms-np.abc-cdn.net.au/c8904ae9d0c567b6fc91e0b3217bd8e7?impolicy=wcms_crop_resize&cropH=467&cropW=350&xPos=175&yPos=0&width=940&height=1254',
+      width: 940,
+      height: 1254,
+      ratio: '3x4',
+      isUndersizedBinary: true
+    },
+    {
+      url:
+        'https://preview-uat.wcms-np.abc-cdn.net.au/c8904ae9d0c567b6fc91e0b3217bd8e7?impolicy=wcms_crop_resize&cropH=467&cropW=350&xPos=175&yPos=0&width=1400&height=1868',
+      width: 1400,
+      height: 1868,
+      ratio: '3x4',
+      isUndersizedBinary: true
+    },
+    {
+      url:
+        'https://preview-uat.wcms-np.abc-cdn.net.au/c8904ae9d0c567b6fc91e0b3217bd8e7?impolicy=wcms_crop_resize&cropH=467&cropW=350&xPos=175&yPos=0&width=2150&height=2869',
+      width: 2150,
+      height: 2869,
+      ratio: '3x4',
+      isUndersizedBinary: true
+    },
+    {
+      url:
+        'https://preview-uat.wcms-np.abc-cdn.net.au/c8904ae9d0c567b6fc91e0b3217bd8e7?impolicy=wcms_crop_resize&cropH=467&cropW=623&xPos=39&yPos=0&width=160&height=120',
+      width: 160,
+      height: 120,
+      ratio: '4x3',
+      isUndersizedBinary: false
+    },
+    {
+      url:
+        'https://preview-uat.wcms-np.abc-cdn.net.au/c8904ae9d0c567b6fc91e0b3217bd8e7?impolicy=wcms_crop_resize&cropH=467&cropW=623&xPos=39&yPos=0&width=240&height=180',
+      width: 240,
+      height: 180,
+      ratio: '4x3',
+      isUndersizedBinary: false
+    },
+    {
+      url:
+        'https://preview-uat.wcms-np.abc-cdn.net.au/c8904ae9d0c567b6fc91e0b3217bd8e7?impolicy=wcms_crop_resize&cropH=467&cropW=623&xPos=39&yPos=0&width=480&height=360',
+      width: 480,
+      height: 360,
+      ratio: '4x3',
+      isUndersizedBinary: false
+    },
+    {
+      url:
+        'https://preview-uat.wcms-np.abc-cdn.net.au/c8904ae9d0c567b6fc91e0b3217bd8e7?impolicy=wcms_crop_resize&cropH=467&cropW=623&xPos=39&yPos=0&width=700&height=525',
+      width: 700,
+      height: 525,
+      ratio: '4x3',
+      isUndersizedBinary: true
+    },
+    {
+      url:
+        'https://preview-uat.wcms-np.abc-cdn.net.au/c8904ae9d0c567b6fc91e0b3217bd8e7?impolicy=wcms_crop_resize&cropH=467&cropW=623&xPos=39&yPos=0&width=940&height=705',
+      width: 940,
+      height: 705,
+      ratio: '4x3',
+      isUndersizedBinary: true
+    },
+    {
+      url:
+        'https://preview-uat.wcms-np.abc-cdn.net.au/c8904ae9d0c567b6fc91e0b3217bd8e7?impolicy=wcms_crop_resize&cropH=467&cropW=623&xPos=39&yPos=0&width=1400&height=1049',
+      width: 1400,
+      height: 1049,
+      ratio: '4x3',
+      isUndersizedBinary: true
+    },
+    {
+      url:
+        'https://preview-uat.wcms-np.abc-cdn.net.au/c8904ae9d0c567b6fc91e0b3217bd8e7?impolicy=wcms_crop_resize&cropH=467&cropW=623&xPos=39&yPos=0&width=2150&height=1612',
+      width: 2150,
+      height: 1612,
+      ratio: '4x3',
+      isUndersizedBinary: true
+    }
+  ]
+};


### PR DESCRIPTION
Remove getImageRendition and getImageRenditions in favour of getImageData.

This has a number of benefits. It means there's much less need to parse the raw Terminus response and data about an image can be strongy typed.

It also normalises the responses for v1 and v2.